### PR TITLE
remove background-services

### DIFF
--- a/libs/we-applet/src/types.ts
+++ b/libs/we-applet/src/types.ts
@@ -184,10 +184,6 @@ export type RenderView =
   | {
       type: 'cross-applet-view';
       view: CrossAppletView;
-    }
-  | {
-      type: 'background-service';
-      view: null;
     };
 
 export type ParentToAppletRequest =

--- a/src/renderer/src/applets/applet-host.ts
+++ b/src/renderer/src/applets/applet-host.ts
@@ -172,7 +172,7 @@ export function buildHeadlessWeClient(weStore: WeStore): WeServices {
 
       const promises: Array<Promise<Array<HrlWithContext>>> = [];
 
-      // TODO fix case where background-service applet host failed to initialize
+      // TODO fix case where applet host failed to initialize
       for (const host of Array.from(hosts.values())) {
         promises.push(
           (async () => {

--- a/src/renderer/src/layout/views/view-frame.ts
+++ b/src/renderer/src/layout/views/view-frame.ts
@@ -1,7 +1,7 @@
 import { css, html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { hashProperty } from '@holochain-open-dev/elements';
-import { EntryHash } from '@holochain/client';
+import { encodeHashToBase64, EntryHash } from '@holochain/client';
 import { consume } from '@lit/context';
 import { RenderView } from '@lightningrodlabs/we-applet';
 
@@ -47,7 +47,11 @@ export class ViewFrame extends LitElement {
     return html`<iframe
       frameborder="0"
       title="TODO"
-      id=${this.iframeId ? this.iframeId : undefined}
+      id=${this.iframeId
+        ? this.iframeId
+        : this.renderView.type === 'applet-view' && this.renderView.view.type === 'main'
+          ? encodeHashToBase64(this.appletHash)
+          : undefined}
       src="${appletOrigin(this.appletHash)}?${renderViewToQueryString(this.renderView)}"
       style="flex: 1; display: block; padding: 0; margin: 0;"
       allow="camera; microphone; clipboard-write;"
@@ -68,7 +72,11 @@ export class ViewFrame extends LitElement {
         return html`<iframe
           frameborder="0"
           title="TODO"
-          id=${this.iframeId ? this.iframeId : undefined}
+          id=${this.iframeId
+            ? this.iframeId
+            : this.renderView.type === 'applet-view' && this.renderView.view.type === 'main'
+              ? encodeHashToBase64(this.appletHash)
+              : undefined}
           src="${iframeSrc}"
           style="flex: 1; display: block; padding: 0; margin: 0;"
           allow="camera; microphone; clipboard-write;"

--- a/src/renderer/src/utils.ts
+++ b/src/renderer/src/utils.ts
@@ -505,3 +505,55 @@ export function notifyAndThrow(message: string) {
   notifyError(message);
   throw new Error(message);
 }
+
+// export function getAllIframes() {
+//   const iframes: HTMLIFrameElement[] = [];
+
+//   // Recursive function to get iframes from a given shadow root
+//   function getIframesFromShadowRoot(shadowRoot: ShadowRoot) {
+//     const shadowIframes = shadowRoot.querySelectorAll('iframe');
+//     Array.from(shadowIframes).forEach((iframe) => {
+//       iframes.push(iframe);
+//     });
+
+//     // Check if the current shadow root itself has any child shadow roots
+//     const childShadowRoots = shadowRoot.querySelectorAll('shadow-root');
+//     console.log('Got child shadowRoots: ', childShadowRoots);
+//     childShadowRoots.forEach((childShadowRoot) => {
+//       if (childShadowRoot.shadowRoot) getIframesFromShadowRoot(childShadowRoot.shadowRoot);
+//     });
+//   }
+
+//   // Get the top-level document's iframes within main shadow root
+//   const mainShadowRoot = document.getElementById('app-container')!.shadowRoot;
+//   getIframesFromShadowRoot(mainShadowRoot!);
+
+//   return iframes;
+// }
+
+export function getAllIframes() {
+  const result: HTMLIFrameElement[] = [];
+
+  // Recursive function to traverse the DOM tree
+  function traverse(node) {
+    // Check if the current node is an iframe
+    if (node.tagName === 'IFRAME') {
+      result.push(node);
+    }
+
+    // Get the shadow root of the node if available
+    const shadowRoot = node.shadowRoot;
+
+    // Traverse child nodes if any
+    if (shadowRoot) {
+      shadowRoot.childNodes.forEach(traverse);
+    } else {
+      node.childNodes.forEach(traverse);
+    }
+  }
+
+  // Start traversing from the main document's body
+  traverse(document.body);
+
+  return result;
+}

--- a/src/renderer/src/we-app.ts
+++ b/src/renderer/src/we-app.ts
@@ -201,7 +201,7 @@ export class WeApp extends LitElement {
       case 'running':
         return html`
           ${this.renderFeedbackBoard()}
-          <main-dashboard></main-dashboard>
+          <main-dashboard id="main-dashboard"></main-dashboard>
         `;
       case 'factoryReset':
         return html`

--- a/src/renderer/src/we-store.ts
+++ b/src/renderer/src/we-store.ts
@@ -605,12 +605,6 @@ export class WeStore {
     await this.adminWebsocket.disableApp({
       installed_app_id: appIdFromAppletHash(appletHash),
     });
-    // remove background-services iframe from DOM
-    const appletHashBase64 = encodeHashToBase64(appletHash);
-    const backgroundIframe = document.getElementById(appletHashBase64);
-    if (backgroundIframe) {
-      backgroundIframe.remove();
-    }
     await this.reloadManualStores();
   }
 


### PR DESCRIPTION
This PR removes the background-services iframes and instead uses the <applet-main> iframes for the same purpose. This change happens because signals emitted by the AppAgentWebsocket otherwise get handled by both background-serivces and main-views which causes troubles.